### PR TITLE
Add signature and disqus to blog posts

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -4,10 +4,7 @@
 
   %h1= data.me.full_name
   .container
-    %p
-      #{data.me.long_description_non_work}. I'm also a #{data.work.job_title.downcase} at&nbsp
-      %a{ href: data.work.url, target: '_blank' }>= data.work.name
-      , #{data.work.short_description}.
+    = partial '/partials/bio'
 
   = partial '/partials/icons'
 

--- a/source/layouts/blog.html.haml
+++ b/source/layouts/blog.html.haml
@@ -22,9 +22,14 @@
   %body
     %main
       %article
-        %h5= link_to(data.me.full_name, '/')
-        %h5= time_tag current_article.date
-        %h1= current_article.title
-        / https://github.com/middleman/middleman-syntax/issues/24
-        = preserve do
-          = yield
+        %header
+          %h5= link_to(data.me.full_name, '/')
+          %h5= time_tag current_article.date
+          %h1= current_article.title
+        %main
+          / https://github.com/middleman/middleman-syntax/issues/24
+          = preserve do
+            = yield
+        %footer
+          = partial '/partials/post_signature'
+          = partial '/partials/disqus'

--- a/source/partials/_bio.html.haml
+++ b/source/partials/_bio.html.haml
@@ -1,0 +1,4 @@
+%p
+  #{data.me.long_description_non_work}. I'm also a #{data.work.job_title.downcase} at&nbsp
+  %a{ href: data.work.url, target: '_blank' }>= data.work.name
+  , #{data.work.short_description}.

--- a/source/partials/_disqus.html.haml
+++ b/source/partials/_disqus.html.haml
@@ -1,0 +1,18 @@
+%section.disqus
+  #disqus_thread
+    :javascript
+      var disqus_config = function () {
+        this.page.url = '#{config[:host] + current_article.url}';
+        this.page.identifier = '#{current_article.url}';
+      };
+
+      (function() {
+        var d = document, s = d.createElement('script');
+        s.src = '//mdzhang.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
+      })();
+
+  %noscript
+    Please enable JavaScript to view the
+    %a{ href: 'https://disqus.com/?ref_noscript' } comments powered by Disqus

--- a/source/partials/_post_signature.html.haml
+++ b/source/partials/_post_signature.html.haml
@@ -1,0 +1,6 @@
+%section.signature
+  %a{ href: '/' }
+    %img.avatar{ src: gravatar_url_small }
+  .description
+    %h4.name= data.me.full_name
+    = partial '/partials/bio'

--- a/source/stylesheets/blog.css.scss.erb
+++ b/source/stylesheets/blog.css.scss.erb
@@ -92,3 +92,37 @@ h4, h5 {
   color: $darker-grey;
   font-weight: bolder;
 }
+
+.disqus {
+  noscript {
+    font-size: 0.8rem;
+    color: $dark-grey;
+    margin: 2rem auto;
+    display: block;
+    text-align: center;
+  }
+}
+
+.signature {
+  padding: 30px 0;
+
+  img {
+    float: left;
+    width: 80px;
+    height: 80px;
+    border-radius: 50%
+  }
+
+  .description {
+    margin-left: 80px;
+    padding-left: 10px;
+
+    h4 {
+      margin: 0;
+    }
+    
+    p {
+      font-size: 0.9rem;
+    }
+  }
+}


### PR DESCRIPTION
## Description

- restructures format to use semantic HTML tags so Firefox/Safari readers work more smoothly
- Adds this:

![screen shot 2016-09-19 at 3 35 10 pm](https://cloud.githubusercontent.com/assets/3429763/18646249/b3cb73b4-7e7e-11e6-9a4c-485ca13cd3ec.png)

- punting on CSS cleanup