### PR TITLE
Fix to pushing deploy branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
         run: hugo --minify
 
       - name: Push changes to deploy branch
-        if: github.ref == 'refs/heads/gh-act-push'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # enable push later
-          token: ${{ secrets.GITHUB_TOKEN }}
           # fetch hugo themes
           submodules: true
           fetch-depth: 0
+          # enable branch push below
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          persist-credentials: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -40,6 +41,7 @@ jobs:
           # branch: deploy/production/site
           branch: deploy/gh-act-push/site
           force: true
+          ssh: true
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,11 @@ jobs:
         run: hugo --minify
 
       - name: Push changes to deploy branch
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: ad-m/github-push-action@master
         with:
           ssh: true
-          # branch: refs/heads/deploy/production/site
-          branch: refs/heads/deploy/gh-act-push/site
+          branch: refs/heads/deploy/production/site
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,14 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # fetch hugo themes
           submodules: true
           fetch-depth: 0
+          # enable branch push below
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          persist-credentials: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -32,12 +35,13 @@ jobs:
         run: hugo --minify
 
       - name: Push changes to deploy branch
-        uses: ad-m/github-push-action@21d44fe9270fd489e49fb30c9590d40adb3abc40
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # branch: deploy/production/site
           branch: deploy/gh-act-push/site
           force: true
+          ssh: true
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,6 @@ permissions:
   id-token: write
   contents: read
 
-  # for GH branch push
-  pull-requests: write
-  issues: write
-  repository-projects: write
-
 on:
   push:
     branches:
@@ -22,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          # enable push later
+          token: ${{ secrets.GITHUB_TOKEN }}
           # fetch hugo themes
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,14 @@
 name: deploy
 
-# for AWS
 permissions:
+  # for AWS
   id-token: write
   contents: read
+
+  # for GH branch push
+  pull-requests: write
+  issues: write
+  repository-projects: write
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,11 +35,12 @@ jobs:
         run: hugo --minify
 
       - name: Push changes to deploy branch
+        # if: github.ref == 'refs/heads/main'
         uses: ad-m/github-push-action@master
         with:
           ssh: true
-          # branch: deploy/production/site
-          branch: deploy/gh-act-push/site
+          # branch: refs/heads/deploy/production/site
+          branch: refs/heads/deploy/gh-act-push/site
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,13 +35,11 @@ jobs:
         run: hugo --minify
 
       - name: Push changes to deploy branch
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: true
           # branch: deploy/production/site
           branch: deploy/gh-act-push/site
-          force: true
-          ssh: true
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,17 @@ jobs:
       - name: Build
         run: hugo --minify
 
+      - name: Push changes to deploy branch
+        if: github.ref == 'refs/heads/gh-act-push'
+        uses: ad-m/github-push-action@0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # branch: deploy/production/site
+          branch: deploy/gh-act-push/site
+          force_with_lease: true
+
       - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::644266224997:role/github-action--mdzhang-com--role

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # branch: deploy/production/site
           branch: deploy/gh-act-push/site
-          force_with_lease: true
+          force: true
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Push changes to deploy branch
         if: github.ref == 'refs/heads/gh-act-push'
-        uses: ad-m/github-push-action@0.6.0
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # branch: deploy/production/site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,14 +15,11 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           # fetch hugo themes
           submodules: true
           fetch-depth: 0
-          # enable branch push below
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          persist-credentials: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -35,13 +32,12 @@ jobs:
         run: hugo --minify
 
       - name: Push changes to deploy branch
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@21d44fe9270fd489e49fb30c9590d40adb3abc40
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # branch: deploy/production/site
           branch: deploy/gh-act-push/site
           force: true
-          ssh: true
 
       - name: Configure AWS credentials
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -115,9 +115,8 @@ jobs:
         run: exit 1
 
       - name: Push changes to deploy branch
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: ad-m/github-push-action@master
         with:
           ssh: true
-          # branch: refs/heads/deploy/production/terraform
-          branch: refs/heads/deploy/gh-act-push/terraform
+          branch: refs/heads/deploy/production/terraform

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # enable branch push below
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          persist-credentials: true
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
@@ -111,9 +115,9 @@ jobs:
         run: exit 1
 
       - name: Push changes to deploy branch
-        if: github.ref == 'refs/heads/main'
-        uses: ad-m/github-push-action@21d44fe9270fd489e49fb30c9590d40adb3abc40
+        # if: github.ref == 'refs/heads/main'
+        uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: deploy/production/terraform
-          force: true
+          ssh: true
+          # branch: refs/heads/deploy/production/terraform
+          branch: refs/heads/deploy/gh-act-push/terraform


### PR DESCRIPTION
Fixes the following issue that occurs on push

```
remote: Permission to mdzhang/mdzhang.com.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/mdzhang/mdzhang.com.git/': The requested URL returned error: 403
```

after 88f86cc3bf5e0c4fba97b2084fcae219137c78cd

Created a [deploy key](https://docs.github.com/en/developers/overview/managing-deploy-keys)